### PR TITLE
Create env measurement

### DIFF
--- a/app/controllers/api/v1/gardens/env_measurements_controller.rb
+++ b/app/controllers/api/v1/gardens/env_measurements_controller.rb
@@ -1,14 +1,28 @@
 class Api::V1::Gardens::EnvMeasurementsController < ApplicationController
-  before_action :set_garden, only: [:index]
+  before_action :set_garden, only: [:index, :create]
 
 	def index
-    render json: EnvMeasurementSerializer.new(@garden.env_measurements)	
-	end	
+    render json: EnvMeasurementSerializer.new(@garden.env_measurements)
+	end
+
+  def create
+    env_measurement = EnvMeasurement.new(env_params)
+    env_measurement.garden_id = @garden.id
+    if env_measurement.save
+      render json: EnvMeasurementSerializer.new(env_measurement), status: :created
+    else
+      render json: "{ Environment measurements failed to record. }", status: :bad_request
+    end
+  end
 
   private
 
+  def env_params
+    params.permit(:soil_temperature, :soil_moisture)
+  end
+
   def set_garden
     @garden = Garden.find_by(id: params[:id])
-    not_found if @garden.nil?  
+    not_found if @garden.nil?
   end
 end

--- a/app/models/env_measurement.rb
+++ b/app/models/env_measurement.rb
@@ -1,3 +1,6 @@
 class EnvMeasurement < ApplicationRecord
 	belongs_to :garden
+
+	validates_numericality_of :soil_temperature
+	validates_numericality_of :soil_moisture, greater_than_or_equal_to: 0
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,9 @@ Rails.application.routes.draw do
     namespace :v1 do
 			namespace :gardens do
 				get '/:id/env_measurements', to: 'env_measurements#index'
+				post '/:id/env_measurements', to: 'env_measurements#create'
 			end
       resources :gardens, only: :show
     end
-  end	
+  end
 end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -11,7 +11,8 @@ close #
 *
 
 ## Current Test Suite:
-### Test Coverage Percentage: x%
+### Overall Test Coverage: x%
+### Model Test Coverage: x%
 - [ ] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [ ] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
 - [ ] Ran the test suite - all tests are passing

--- a/spec/models/env_measurement_spec.rb
+++ b/spec/models/env_measurement_spec.rb
@@ -4,4 +4,11 @@ RSpec.describe EnvMeasurement, type: :model do
 	describe "relationships" do
 		it { should belong_to(:garden) }
 	end
+
+	describe	"validations" do
+		it { should validate_numericality_of(:soil_temperature) }
+
+		it { should validate_numericality_of(:soil_moisture).
+			is_greater_than_or_equal_to(0) }
+	end
 end

--- a/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
+++ b/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
@@ -43,4 +43,17 @@ describe "env_measurements api", type: :request do
     expect(result[:data][:attributes].count).to eq(3)
     expect(result[:data][:attributes].keys).to eq([:soil_temperature, :soil_moisture, :created_at])
 	end
+
+	it "doesn't create an env_measurement if param values wrong type" do
+		post "/api/v1/gardens/#{@garden.id}/env_measurements", params: {
+      "soil_temperature": "fiftyfive",
+      "soil_moisture": "eighty"
+    }
+
+		expect(response.status).to eq(400)
+
+    result = JSON.parse(response.body)
+
+    expect(result).to eq("{ Environment measurements failed to record. }")
+	end
 end

--- a/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
+++ b/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
@@ -3,16 +3,16 @@ require 'rails_helper'
 describe "env_measurements api", type: :request do
 	before :each do
 		@garden = create(:garden)
-		@em_1 = create(:env_measurement, garden: @garden)	
-		@em_2 = create(:env_measurement, garden: @garden)	
-		@em_3 = create(:env_measurement, garden: @garden)	
-		@em_4 = create(:env_measurement, garden: @garden)	
-		@em_5 = create(:env_measurement, garden: @garden)	
-		@em_6 = create(:env_measurement, garden: @garden)	
-		@em_7 = create(:env_measurement, garden: @garden)	
-		@em_8 = create(:env_measurement, garden: @garden)	
+		@em_1 = create(:env_measurement, garden: @garden)
+		@em_2 = create(:env_measurement, garden: @garden)
+		@em_3 = create(:env_measurement, garden: @garden)
+		@em_4 = create(:env_measurement, garden: @garden)
+		@em_5 = create(:env_measurement, garden: @garden)
+		@em_6 = create(:env_measurement, garden: @garden)
+		@em_7 = create(:env_measurement, garden: @garden)
+		@em_8 = create(:env_measurement, garden: @garden)
 	end
-	
+
 	it "Sends a garden's associated env_measurements" do
 		get "/api/v1/gardens/#{@garden.id}/env_measurements"
 
@@ -29,5 +29,18 @@ describe "env_measurements api", type: :request do
     error = JSON.parse(response.body, symbolize_names: true)[:error]
     expect(error).to eq("Garden Not Found")
 	end
-end
 
+	it "creates an env_measurement" do
+		post "/api/v1/gardens/#{@garden.id}/env_measurements", params: {
+      "soil_temperature": 55.52,
+      "soil_moisture": 85.33
+    }
+
+    expect(response).to be_successful
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(result[:data][:attributes].count).to eq(3)
+    expect(result[:data][:attributes].keys).to eq([:soil_temperature, :soil_moisture, :created_at])
+	end
+end

--- a/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
+++ b/spec/requests/api/v1/gardens/env_measurements/env_measurements_request_spec.rb
@@ -52,8 +52,6 @@ describe "env_measurements api", type: :request do
 
 		expect(response.status).to eq(400)
 
-    result = JSON.parse(response.body)
-
-    expect(result).to eq("{ Environment measurements failed to record. }")
+    expect(response.body).to eq("{ Environment measurements failed to record. }")
 	end
 end


### PR DESCRIPTION
## Changes proposed in this pull request:
* Adds POST request to api/v1/gardens/:id/env_measurements which takes soil_temperature and soil_moisture parameters and creates record in env_measurements table.

## Card(s) closed in this pull request:
close #14 

## What did you struggle on to complete?
* Didn't struggle on anything, this is a pretty straightforward create action. We're also not validating presence of soil_temperature or soil_moisture which made this easier since it didn't require extra logic in case either or both of those were missing.

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas