### PR TITLE
Adds ability to send  params with api/v1/gardens/:id/jobs GET request to filter for only new jobs

### DIFF
--- a/app/controllers/api/v1/gardens/jobs_controller.rb
+++ b/app/controllers/api/v1/gardens/jobs_controller.rb
@@ -2,7 +2,13 @@ class Api::V1::Gardens::JobsController < ApplicationController
   before_action :set_garden, only: [:index, :create]
 
   def index
-    render json: JobSerializer.new(@garden.jobs)
+    if job_params[:seconds_ago] == nil
+      render json: JobSerializer.new(@garden.jobs)
+    elsif job_params[:seconds_ago].to_i > 0
+      render json: JobSerializer.new(@garden.jobs.where('created_at >= ?', Time.now - job_params[:seconds_ago].to_i))
+    else
+      render json: "{ Job request failed. }", status: :bad_request
+    end
   end
 
   def create
@@ -18,11 +24,11 @@ class Api::V1::Gardens::JobsController < ApplicationController
   private
 
   def job_params
-    params.permit(:name)
+    params.permit(:name, :seconds_ago)
   end
 
   def set_garden
     @garden = Garden.find_by(id: params[:id])
     not_found if @garden.nil?
-  end 
+  end
 end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :job do
-    name { "MyString" }
+    sequence(:name) { |n| "Job #{n}" }
   end
 end

--- a/spec/requests/api/v1/gardens/jobs/jobs_request_spec.rb
+++ b/spec/requests/api/v1/gardens/jobs/jobs_request_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 describe "jobs api", type: :request do
 	before :each do
 		@garden = create(:garden)
-		@job_1 = create(:job, garden: @garden)
-		@job_2 = create(:job, garden: @garden)
-		@job_3 = create(:job, garden: @garden)
-		@job_4 = create(:job, garden: @garden)
-		@job_5 = create(:job, garden: @garden)
-		@job_6 = create(:job, garden: @garden)
-		@job_7 = create(:job, garden: @garden)
-		@job_8 = create(:job, garden: @garden)
+		@job_1 = create(:job, garden: @garden, created_at: 4.seconds.ago)
+		@job_2 = create(:job, garden: @garden, created_at: 5.seconds.ago)
+		@job_3 = create(:job, garden: @garden, created_at: 6.seconds.ago)
+		@job_4 = create(:job, garden: @garden, created_at: 5.minutes.ago)
+		@job_5 = create(:job, garden: @garden, created_at: 15.minutes.ago)
+		@job_6 = create(:job, garden: @garden, created_at: 20.minutes.ago)
+		@job_7 = create(:job, garden: @garden, created_at: 25.minutes.ago)
+		@job_8 = create(:job, garden: @garden, created_at: 900.minutes.ago)
 	end
 
 	it "Sends a garden's associated jobs" do
@@ -18,15 +18,32 @@ describe "jobs api", type: :request do
 
 		expect(response).to have_http_status(200)
 		garden_data = JSON.parse(response.body, symbolize_names: true)[:data]
-    expect(garden_data.first[:attributes][:name]).to eq(@job_1.name)
+    expect(garden_data[0][:attributes][:name]).to eq(@job_1.name)
 	end
 
-	it "returns 404 for a garden not in the DB" do
+	it "Returns 404 for a garden not in the DB" do
 		get "/api/v1/gardens/#{@garden.id + 1}/jobs"
 
     expect(response.status).to eq(404)
     error = JSON.parse(response.body, symbolize_names: true)[:error]
     expect(error).to eq("Garden Not Found")
+	end
+
+	it "Sends a garden's new jobs" do
+		get "/api/v1/gardens/#{@garden.id}/jobs?seconds_ago=5"
+
+		expect(response).to have_http_status(200)
+		garden_data = JSON.parse(response.body, symbolize_names: true)[:data]
+		expect(garden_data[0][:attributes][:name]).to eq(@job_1.name)
+		expect(garden_data[1]).to eq(nil)
+		expect(garden_data[2]).to eq(nil)
+	end
+
+	it "Returns 400 for garden's new jobs if bad params provided" do
+		get "/api/v1/gardens/#{@garden.id}/jobs?seconds_ago=five"
+
+		expect(response).to have_http_status(400)
+		expect(response.body).to eq("{ Job request failed. }")
 	end
 
 	it "creates an job" do


### PR DESCRIPTION
## Changes proposed in this pull request:
Adds ability to send  params with api/v1/gardens/:id/jobs GET request to filter for only new jobs

## What did you struggle on to complete?
* Sad path testing kept resulting in a 785 unexpected token error. Issue was with the test, not the code.

## Current Test Suite:
### Overall Test Coverage: 100%
### Model Test Coverage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x]  Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas