### PR TITLE
Daily avg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'pry'
 	gem 'factory_bot_rails'
 	gem 'simplecov'
+  gem 'table_print'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    table_print (1.5.6)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -199,6 +200,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  table_print
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/api/v1/gardens/daily_avg_moisture_controller.rb
+++ b/app/controllers/api/v1/gardens/daily_avg_moisture_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::Gardens::DailyAvgMoistureController < ApplicationController
+  before_action :set_garden, only: [:index]
+
+  def index
+    render json: DailyAvgMoistureSerializer.new(@garden.daily_avg_moisture(daily_avg_moisture_params[:days])).daily_avg, status: :ok
+  end
+
+  private
+
+  def daily_avg_moisture_params
+    params.permit(:days)
+  end
+
+  def set_garden
+    @garden = Garden.find_by(id: params[:id])
+    not_found if @garden.nil?
+  end
+
+end

--- a/app/controllers/api/v1/gardens/env_measurements_controller.rb
+++ b/app/controllers/api/v1/gardens/env_measurements_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::Gardens::EnvMeasurementsController < ApplicationController
   before_action :set_garden, only: [:index, :create]
 
-	def index
-    render json: EnvMeasurementSerializer.new(@garden.env_measurements)
+	def inde
+    render json: EnvMeasurementSerializer.new(@garden.env_measurements), status: :ok
 	end
 
   def create

--- a/app/controllers/api/v1/gardens/env_measurements_controller.rb
+++ b/app/controllers/api/v1/gardens/env_measurements_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Gardens::EnvMeasurementsController < ApplicationController
   before_action :set_garden, only: [:index, :create]
 
-	def inde
+	def index
     render json: EnvMeasurementSerializer.new(@garden.env_measurements), status: :ok
 	end
 

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -4,4 +4,13 @@ class Garden < ApplicationRecord
 	# relationships
 	has_many :env_measurements
 	has_many :jobs
+
+	def daily_avg_moisture(days)
+		x = env_measurements.where("created_at >= ? AND created_at <= ?",
+			Time.now.beginning_of_day - (days * 86400),
+			Time.now.beginning_of_day)
+		.group("DATE_TRUNC('day', created_at)")
+		.average(:soil_moisture)
+	end
+
 end

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -6,8 +6,8 @@ class Garden < ApplicationRecord
 	has_many :jobs
 
 	def daily_avg_moisture(days)
-		x = env_measurements.where("created_at >= ? AND created_at <= ?",
-			Time.now.beginning_of_day - (days * 86400),
+		env_measurements.where("created_at >= ? AND created_at <= ?",
+			Time.now.beginning_of_day - (days.to_i * 86400),
 			Time.now.beginning_of_day)
 		.group("DATE_TRUNC('day', created_at)")
 		.average(:soil_moisture)

--- a/app/serializers/daily_avg_moisture_serializer.rb
+++ b/app/serializers/daily_avg_moisture_serializer.rb
@@ -1,0 +1,15 @@
+class DailyAvgMoistureSerializer
+
+  def initialize(days_hash)
+    @days_hash = days_hash
+  end
+
+  def daily_avg
+    {
+      data: {
+        attributes: @days_hash
+      }
+    }
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module GardenPiBe
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # config.time_zone = "America/Denver"
+    config.active_record.default_timezone = :local
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,11 @@ Rails.application.routes.draw do
 			namespace :gardens do
 				get '/:id/env_measurements', to: 'env_measurements#index'
         post '/:id/env_measurements', to: 'env_measurements#create'
+
         get '/:id/jobs', to: 'jobs#index'
         post '/:id/jobs', to: 'jobs#create'
+
+				get '/:id/daily_avg_moisture', to: 'daily_avg_moisture#index'
 			end
       resources :gardens, only: :show
     end

--- a/spec/factories/gardens.rb
+++ b/spec/factories/gardens.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :garden do
     sequence(:name) { |n| "Garden #{n}" }
-		sequence(:latitude) { |n| (40.1234 - (n + 1))}
-		sequence(:longitude) { |n| (95.4321 + (n - 1))}
+		sequence(:latitude) { |n| (40.1234 - (n))}
+		sequence(:longitude) { |n| (95.4321 + (n))}
     max_moisture { 40 }
     min_moisture { 20 }
     auto_water { true }

--- a/spec/models/garden_spec.rb
+++ b/spec/models/garden_spec.rb
@@ -5,4 +5,77 @@ RSpec.describe Garden, type: :model do
 		it { should have_many :env_measurements }
 		it { should have_many :jobs }
 	end
+
+	describe "#daily_avg" do
+		before :each do
+			@garden = create(:garden)
+
+			today = Time.zone.now.beginning_of_day
+
+			one_day_ago    = today          - 86400
+			two_days_ago   = one_day_ago    - 86400
+			three_days_ago = two_days_ago   - 86400
+			four_days_ago  = three_days_ago - 86400
+			five_days_ago  = four_days_ago  - 86400
+			six_days_ago   = five_days_ago  - 86400
+			seven_days_ago = six_days_ago   - 86400
+			eight_days_ago = seven_days_ago - 86400
+			x = 0
+
+			until today == one_day_ago
+			  @garden.env_measurements.create!(soil_temperature: 10, soil_moisture: 10, created_at: x.minutes.ago)
+			  today = today - 900
+			  x = x + 15
+			end
+
+			until one_day_ago == two_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 20, soil_moisture: 20, created_at: x.minutes.ago)
+			  one_day_ago = one_day_ago - 900
+			  x = x + 15
+			end
+
+			until two_days_ago == three_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 30, soil_moisture: 30, created_at: x.minutes.ago)
+			  two_days_ago = two_days_ago - 900
+			  x = x + 15
+			end
+
+			until three_days_ago == four_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 40, soil_moisture: 40, created_at: x.minutes.ago)
+			  three_days_ago = three_days_ago - 900
+			  x = x + 15
+			end
+
+			until four_days_ago == five_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 50, soil_moisture: 50, created_at: x.minutes.ago)
+			  four_days_ago = four_days_ago - 900
+			  x = x + 15
+			end
+
+			until five_days_ago == six_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 60, soil_moisture: 60, created_at: x.minutes.ago)
+			  five_days_ago = five_days_ago - 900
+			  x = x + 15
+			end
+
+			until six_days_ago == seven_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 70, soil_moisture: 70, created_at: x.minutes.ago)
+			  six_days_ago = six_days_ago - 900
+			  x = x + 15
+			end
+
+			until seven_days_ago == eight_days_ago
+			  @garden.env_measurements.create!(soil_temperature: 80, soil_moisture: 80, created_at: x.minutes.ago)
+			  seven_days_ago = seven_days_ago - 900
+			  x = x + 15
+			end
+    end
+
+		it "returns daily average moisture for given number of days" do
+			expect(@garden.daily_avg_moisture(1).count).to eq(1)
+			expect(@garden.daily_avg_moisture(2).count).to eq(2)
+			expect(@garden.daily_avg_moisture(3).count).to eq(3)
+			expect(@garden.daily_avg_moisture(7).count).to eq(7)
+		end
+	end
 end

--- a/spec/requests/api/v1/gardens/daily_avg_moisture_request_spec.rb
+++ b/spec/requests/api/v1/gardens/daily_avg_moisture_request_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe "gardens api", type: :request do
+	before :each do
+		@garden = create(:garden)
+
+    today = Time.zone.now.beginning_of_day
+    one_day_ago    = today          - 86400
+    two_days_ago   = one_day_ago    - 86400
+    three_days_ago = two_days_ago   - 86400
+    four_days_ago  = three_days_ago - 86400
+    five_days_ago  = four_days_ago  - 86400
+    six_days_ago   = five_days_ago  - 86400
+    seven_days_ago = six_days_ago   - 86400
+    eight_days_ago = seven_days_ago - 86400
+    x = 0
+
+    until today == one_day_ago
+      @garden.env_measurements.create!(soil_temperature: 10, soil_moisture: 10, created_at: x.minutes.ago)
+      today = today - 900
+      x = x + 15
+    end
+
+    until one_day_ago == two_days_ago
+      @garden.env_measurements.create!(soil_temperature: 20, soil_moisture: 20, created_at: x.minutes.ago)
+      one_day_ago = one_day_ago - 900
+      x = x + 15
+    end
+
+    until two_days_ago == three_days_ago
+      @garden.env_measurements.create!(soil_temperature: 30, soil_moisture: 30, created_at: x.minutes.ago)
+      two_days_ago = two_days_ago - 900
+      x = x + 15
+    end
+
+    until three_days_ago == four_days_ago
+      @garden.env_measurements.create!(soil_temperature: 40, soil_moisture: 40, created_at: x.minutes.ago)
+      three_days_ago = three_days_ago - 900
+      x = x + 15
+    end
+
+    until four_days_ago == five_days_ago
+      @garden.env_measurements.create!(soil_temperature: 50, soil_moisture: 50, created_at: x.minutes.ago)
+      four_days_ago = four_days_ago - 900
+      x = x + 15
+    end
+
+    until five_days_ago == six_days_ago
+      @garden.env_measurements.create!(soil_temperature: 60, soil_moisture: 60, created_at: x.minutes.ago)
+      five_days_ago = five_days_ago - 900
+      x = x + 15
+    end
+
+    until six_days_ago == seven_days_ago
+      @garden.env_measurements.create!(soil_temperature: 70, soil_moisture: 70, created_at: x.minutes.ago)
+      six_days_ago = six_days_ago - 900
+      x = x + 15
+    end
+
+    until seven_days_ago == eight_days_ago
+      @garden.env_measurements.create!(soil_temperature: 80, soil_moisture: 80, created_at: x.minutes.ago)
+      seven_days_ago = seven_days_ago - 900
+      x = x + 15
+    end
+	end
+
+	it "Shows an individual garden" do
+		get "/api/v1/gardens/#{@garden.id}/daily_avg_moisture?days=3"
+
+		expect(response).to have_http_status(200)
+		data = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(data[:attributes].count).to eq(3)
+	end
+end

--- a/spec/requests/api/v1/gardens/gardens_request_spec.rb
+++ b/spec/requests/api/v1/gardens/gardens_request_spec.rb
@@ -4,14 +4,14 @@ describe "gardens api", type: :request do
 	before :each do
 		@garden = create(:garden)
 	end
-	
+
 	it "Shows an individual garden" do
 		get "/api/v1/gardens/#{@garden.id}"
 
 		expect(response).to have_http_status(200)
 
 		garden_data = JSON.parse(response.body, symbolize_names: true)[:data]
-  
+
     expect(garden_data[:id].to_i).to eq(@garden.id)
     expect(garden_data[:attributes][:latitude].to_f).to eq(@garden.latitude)
     expect(garden_data[:attributes][:longitude].to_f).to eq(@garden.longitude)
@@ -25,5 +25,3 @@ describe "gardens api", type: :request do
     expect(error).to eq("Garden Not Found")
 	end
 end
-
-


### PR DESCRIPTION
## Changes proposed in this pull request:
* This PR adds the `api/v1/gardens/:id/daily_avg_moisture` endpoint which takes a `days` param as an integer and returns a daily average moisture for that number of days in the past (i.e. if today is Monday and 7 is passed in as the days param, then daily averages for each of Sunday through last Monday will be returned).

## Card(s) closed in this pull request:
close #27

## What did you struggle on to complete?
*This was a tough story to test based on the number of endpoints in a day, and the timezones set in Rails and separately in Postgresql timestamps.

Need to make the tests more robust, but FE needs this endpoint so OK with this for the time being.
## Current Test Suite:
### Overall Test Coverage: 100%
### Model Test Coverage: 100%
- [ ] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - ONE TEST IS FAILING. @Mycobee would you take a look at the env_request_spec file please?
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
* [Setting default timezone in Rails](https://stackoverflow.com/questions/6118779/how-to-change-default-timezone-for-active-record-in-rails)
