### PR TITLE
Users sessions

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::SessionsController < ApplicationController
+
+  def create
+    user = User.find_by(email: params[:email])
+    if user && user.authenticate(params[:password])
+      if user.api_key_active
+        session[:user_id] = user.id
+        render json: UserSerializer.new(user), status: :ok
+      else
+        render json: "{ Your api key is not active. }".to_json, status: :bad_request
+      end
+    else
+      render json: "{ Please check that the email and password you've entered are correct. }".to_json, status: :unauthorized
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 				get '/:id/daily_avg_moisture', to: 'daily_avg_moisture#index'
 			end
 			resources :users, only: :create
+			resources :sessions, only: :create
       resources :gardens, only: :show
     end
   end

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe "Sessions API" do
     expect(result).to eq("{ Please check that the email and password you've entered are correct. }")
   end
 
+  it "doesn't create a User session if api key is inactive" do
+    @user.update(api_key_active: false)
+
+    post "/api/v1/sessions", params: {
+      "email": @user.email,
+      "password": @user.password
+      }
+
+    expect(response.status).to eq(400)
+
+    result = JSON.parse(response.body)
+    expect(result).to eq("{ Your api key is not active. }")
+  end
 end

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -18,4 +18,17 @@ RSpec.describe "Sessions API" do
     expect(result.keys).to eq(["api_key"])
   end
 
+  it "doesn't create a User session if invalid credentials" do
+    post "/api/v1/sessions", params: {
+      "email": @user.email,
+      "password": "wrong"
+      }
+
+    expect(response.status).to eq(401)
+
+    result = JSON.parse(response.body)
+
+    expect(result).to eq("{ Please check that the email and password you've entered are correct. }")
+  end
+
 end

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions API" do
+  before :each do
+    @user = User.create!( first_name: "first", last_name: "last", email: "user1@example.com", password: "password", password_confirmation: "password")
+  end
+
+  it "creates a User session" do
+    post "/api/v1/sessions", params: {
+      "email": @user.email,
+      "password": @user.password
+      }
+
+    expect(response).to be_successful
+
+    result = JSON.parse(response.body)
+
+    expect(result.keys).to eq(["api_key"])
+  end
+
+end


### PR DESCRIPTION
## Changes proposed in this pull request:
This PR adds the ability to send a POST request to api/v1/sessions with an email address and password and to receive a JSON formatted object containing an api_key if the credentials are valid.

## Card(s) closed in this pull request:
close #38

## What did you struggle on to complete?
I struggled with a sad path test in the case where a User sent valid credentials but their api_key had been deactivated. I was using a before :each action in the spec, and inside of the specific test `@user.api_key_active = false` which does not persist in the database. Instead I had to use `@user.update(api_key_active: false)` which does persist in the database.

## Current Test Suite:
### Overall Test Coverage: 100%
### Model Test Coverage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
[This helped remind me what method to use in my test to persist the attribute change in the db](https://davidverhasselt.com/set-attributes-in-activerecord/)
