### PR TITLE
Garden create endpoint

### DIFF
--- a/app/controllers/api/v1/gardens/env_measurements_controller.rb
+++ b/app/controllers/api/v1/gardens/env_measurements_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::Gardens::EnvMeasurementsController < ApplicationController
 
   def set_garden
     @garden = Garden.find_by(id: params[:id])
-    not_found if @garden.nil?
+    garden_not_found if @garden.nil?
   end
 
   def water_if_dry

--- a/app/controllers/api/v1/gardens/jobs_controller.rb
+++ b/app/controllers/api/v1/gardens/jobs_controller.rb
@@ -29,6 +29,6 @@ class Api::V1::Gardens::JobsController < ApplicationController
 
   def set_garden
     @garden = Garden.find_by(id: params[:id])
-    not_found if @garden.nil?
+    garden_not_found if @garden.nil?
   end
 end

--- a/app/controllers/api/v1/gardens_controller.rb
+++ b/app/controllers/api/v1/gardens_controller.rb
@@ -1,14 +1,13 @@
 class Api::V1::GardensController < ApplicationController
   before_action :set_garden, only: [:show]
+  before_action :authenticate_user, only: [:create]
 
 	def show
     render json: GardenSerializer.new(@garden)	
 	end	
 
   def create
-    auth_key = request.headers["Authorization"]
-    user = User.find_by(api_key: auth_key)
-    garden = user.gardens.create(garden_params) 
+    garden = @user.gardens.create(garden_params) 
     render json: GardenSerializer.new(garden), status: :created
   end
 
@@ -18,8 +17,14 @@ class Api::V1::GardensController < ApplicationController
     params.require(:garden).permit(:name, :latitude, :longitude, :max_moisture, :min_moisture, :auto_water)
   end
 
+  def authenticate_user
+    auth_key = request.headers["Authorization"]
+    @user = User.find_by(api_key: auth_key)
+    unauthorized if @user.nil?
+  end
+
   def set_garden
     @garden = Garden.find_by(id: params[:id])
-    not_found if @garden.nil?  
+    garden_not_found if @garden.nil?  
   end
 end

--- a/app/controllers/api/v1/gardens_controller.rb
+++ b/app/controllers/api/v1/gardens_controller.rb
@@ -7,8 +7,12 @@ class Api::V1::GardensController < ApplicationController
 	end	
 
   def create
-    garden = @user.gardens.create(garden_params) 
-    render json: GardenSerializer.new(garden), status: :created
+    garden = @user.gardens.new(garden_params) 
+    if garden.save
+      render json: GardenSerializer.new(garden), status: :created
+    else
+      bad_request
+    end
   end
 
   private

--- a/app/controllers/api/v1/gardens_controller.rb
+++ b/app/controllers/api/v1/gardens_controller.rb
@@ -5,7 +5,18 @@ class Api::V1::GardensController < ApplicationController
     render json: GardenSerializer.new(@garden)	
 	end	
 
+  def create
+    auth_key = request.headers["Authorization"]
+    user = User.find_by(api_key: auth_key)
+    garden = user.gardens.create(garden_params) 
+    render json: GardenSerializer.new(garden), status: :created
+  end
+
   private
+
+  def garden_params
+    params.require(:garden).permit(:name, :latitude, :longitude, :max_moisture, :min_moisture, :auto_water)
+  end
 
   def set_garden
     @garden = Garden.find_by(id: params[:id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::API
-	def not_found
+	def garden_not_found
     render json: { error: "Garden Not Found" }, status: :not_found
 	end
+
+  def unauthorized
+    render json: { error: "Invalid Credentials" }, status: :unauthorized
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,8 @@ class ApplicationController < ActionController::API
   def unauthorized
     render json: { error: "Invalid Credentials" }, status: :unauthorized
   end
+
+  def bad_request
+    render json: { error: "Bad Request" }, status: :bad_request
+  end
 end

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -2,6 +2,7 @@ class Garden < ApplicationRecord
 	# validations
   validates_presence_of :name, :latitude, :longitude
   validates_numericality_of :latitude, :longitude, :max_moisture, :min_moisture
+  validates :min_moisture, presence: true, if: :auto_water
 
 	# relationships
 	has_many :env_measurements

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -1,5 +1,7 @@
 class Garden < ApplicationRecord
 	# validations
+  validates_presence_of :name, :latitude, :longitude
+  validates_numericality_of :latitude, :longitude, :max_moisture, :min_moisture
 
 	# relationships
 	has_many :env_measurements

--- a/app/serializers/garden_serializer.rb
+++ b/app/serializers/garden_serializer.rb
@@ -1,4 +1,4 @@
 class GardenSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :name, :latitude, :longitude
+  attributes :id, :name, :latitude, :longitude, :max_moisture, :min_moisture, :auto_water
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 			post '/sessions', to: 'sessions#create'
   		delete '/sessions', to: 'sessions#destroy'
 			resources :users, only: :create
-      resources :gardens, only: :show
+      resources :gardens, only: [:show, :create]
     end
   end
 end

--- a/db/migrate/20190924195103_add_default_value_to_auto_water.rb
+++ b/db/migrate/20190924195103_add_default_value_to_auto_water.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToAutoWater < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default(
+        :gardens,
+        :auto_water,
+        false 
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_164031) do
+ActiveRecord::Schema.define(version: 2019_09_24_195103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2019_09_23_164031) do
     t.datetime "updated_at", null: false
     t.float "max_moisture"
     t.float "min_moisture"
-    t.boolean "auto_water"
+    t.boolean "auto_water", default: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_gardens_on_user_id"
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:first_name) { |n| "First #{n}" }
     sequence(:last_name) { |n| "Last #{n}" }
     sequence(:email) { |n| "#{n}user@email.com" }
-    sequence(:password_digest) { |n| "#{n}password" }
+    sequence(:password) { |n| "#{n}password" }
     sequence(:api_key) { |n| "#{n}api_key" }
     api_key_active { true }
   end

--- a/spec/models/garden_spec.rb
+++ b/spec/models/garden_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Garden, type: :model do
     it { should validate_numericality_of :longitude  }
     it { should validate_numericality_of :max_moisture  }
     it { should validate_numericality_of :min_moisture  }
+    Garden.new(auto_water: true).should validate_presence_of(:min_moisture)
   end
 
 	describe "relationships" do

--- a/spec/models/garden_spec.rb
+++ b/spec/models/garden_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Garden, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :latitude }
+    it { should validate_presence_of :longitude }
+    it { should validate_numericality_of :latitude }
+    it { should validate_numericality_of :longitude  }
+    it { should validate_numericality_of :max_moisture  }
+    it { should validate_numericality_of :min_moisture  }
+  end
+
 	describe "relationships" do
 		it { should have_many :env_measurements }
 		it { should have_many :jobs }

--- a/spec/models/garden_spec.rb
+++ b/spec/models/garden_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Garden, type: :model do
     it { should validate_numericality_of :longitude  }
     it { should validate_numericality_of :max_moisture  }
     it { should validate_numericality_of :min_moisture  }
-    Garden.new(auto_water: true).should validate_presence_of(:min_moisture)
+
+    context "if auto_water" do
+      before { allow(subject).to receive(:auto_water).and_return(true) }
+        it { should validate_presence_of(:min_moisture) }
+    end
   end
 
 	describe "relationships" do

--- a/spec/requests/api/v1/gardens/gardens_request_spec.rb
+++ b/spec/requests/api/v1/gardens/gardens_request_spec.rb
@@ -32,12 +32,14 @@ describe "gardens api", type: :request do
     headers = { "Authorization": @user.api_key } 
 
     post "/api/v1/gardens", params: {
-      "name": "Backyard Raised Bed",
-      "latitude": 39.742043,
-      "longitude": -104.991531,
-      "max_moisture": 82.5,
-      "min_moisture": 22.5,
-      "auto_water": "false"
+      "garden": {
+        "name": "Backyard Raised Bed",
+        "latitude": 39.742043,
+        "longitude": -104.991531,
+        "max_moisture": 82.5,
+        "min_moisture": 22.5,
+        "auto_water": "false"
+        }
       },
       headers: headers
 

--- a/spec/requests/api/v1/gardens/gardens_request_spec.rb
+++ b/spec/requests/api/v1/gardens/gardens_request_spec.rb
@@ -37,8 +37,7 @@ describe "gardens api", type: :request do
         "latitude": 39.742043,
         "longitude": -104.991531,
         "max_moisture": 82.5,
-        "min_moisture": 22.5,
-        "auto_water": "false"
+        "min_moisture": 22.5
         }
       },
       headers: headers
@@ -53,7 +52,7 @@ describe "gardens api", type: :request do
     expect(garden_data[:attributes][:longitude].to_f).to eq(new_garden.longitude)
     expect(garden_data[:attributes][:max_moisture].to_f).to eq(new_garden.max_moisture)
     expect(garden_data[:attributes][:min_moisture].to_f).to eq(new_garden.min_moisture)
-    expect(garden_data[:attributes][:auto_water]).to eq(new_garden.auto_water)
+    expect(garden_data[:attributes][:auto_water]).to eq(false)
 	end
 
 	it "returns 401 for an unauthorized request" do
@@ -75,4 +74,24 @@ describe "gardens api", type: :request do
     error = JSON.parse(response.body, symbolize_names: true)[:error]
     expect(error).to eq("Invalid Credentials")
 	end
+
+  it "returns 400 for a bad request" do
+    headers = { "Authorization": @user.api_key } 
+
+    post "/api/v1/gardens", params: {
+      "garden": {
+        "name": "Backyard Raised Bed",
+        "latitude": "Chicken Nuggets",
+        "longitude": -104.991531,
+        "max_moisture": 82.5,
+        "min_moisture": 22.5,
+        "auto_water": "false"
+        }
+      },
+      headers: headers
+
+    expect(response.status).to eq(400)
+    error = JSON.parse(response.body, symbolize_names: true)[:error]
+    expect(error).to eq("Bad Request")
+  end
 end

--- a/spec/requests/api/v1/gardens/gardens_request_spec.rb
+++ b/spec/requests/api/v1/gardens/gardens_request_spec.rb
@@ -55,4 +55,24 @@ describe "gardens api", type: :request do
     expect(garden_data[:attributes][:min_moisture].to_f).to eq(new_garden.min_moisture)
     expect(garden_data[:attributes][:auto_water]).to eq(new_garden.auto_water)
 	end
+
+	it "returns 401 for an unauthorized request" do
+    headers = { "Authorization": "8675309jenn3" } 
+
+    post "/api/v1/gardens", params: {
+      "garden": {
+        "name": "Backyard Raised Bed",
+        "latitude": 39.742043,
+        "longitude": -104.991531,
+        "max_moisture": 82.5,
+        "min_moisture": 22.5,
+        "auto_water": "false"
+        }
+      },
+      headers: headers
+
+    expect(response.status).to eq(401)
+    error = JSON.parse(response.body, symbolize_names: true)[:error]
+    expect(error).to eq("Invalid Credentials")
+	end
 end

--- a/spec/requests/api/v1/gardens/gardens_request_spec.rb
+++ b/spec/requests/api/v1/gardens/gardens_request_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 describe "gardens api", type: :request do
 	before :each do
 		@garden = create(:garden)
+    @user = create(:user) 
 	end
 
+  # Garden Show Specs
 	it "Shows an individual garden" do
 		get "/api/v1/gardens/#{@garden.id}"
 
@@ -23,5 +25,32 @@ describe "gardens api", type: :request do
     expect(response.status).to eq(404)
     error = JSON.parse(response.body, symbolize_names: true)[:error]
     expect(error).to eq("Garden Not Found")
+	end
+
+  # Garden Create Specs
+	it "Creates a garden" do
+    headers = { "Authorization": @user.api_key } 
+
+    post "/api/v1/gardens", params: {
+      "name": "Backyard Raised Bed",
+      "latitude": 39.742043,
+      "longitude": -104.991531,
+      "max_moisture": 82.5,
+      "min_moisture": 22.5,
+      "auto_water": "false"
+      },
+      headers: headers
+
+		expect(response).to have_http_status(201)
+
+		garden_data = JSON.parse(response.body, symbolize_names: true)[:data]
+    new_garden = Garden.last
+
+    expect(garden_data[:id].to_i).to eq(new_garden.id)
+    expect(garden_data[:attributes][:latitude].to_f).to eq(new_garden.latitude)
+    expect(garden_data[:attributes][:longitude].to_f).to eq(new_garden.longitude)
+    expect(garden_data[:attributes][:max_moisture].to_f).to eq(new_garden.max_moisture)
+    expect(garden_data[:attributes][:min_moisture].to_f).to eq(new_garden.min_moisture)
+    expect(garden_data[:attributes][:auto_water]).to eq(new_garden.auto_water)
 	end
 end


### PR DESCRIPTION
## Changes proposed in this pull request:
* This PR adds the create specs and functionality to the garden model.  Validations are added for presence of name, latitude, and longitude.   Also added are numericality validations for latitude, longitude, max_moisture, and min_moisture. A conditional presence validation for min_moisture is added when `Garden.auto_water` is true.   A migration adds a default value of false to auto_water.  Error handling is present for both bad requests and invalid credentials. 


## Card(s) closed in this pull request:
close #35

## What did you struggle on to complete?
* No current blockers

## Current Test Suite:
### Overall Test Coverage: 100%
### Model Test Coverage: 100%
- [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
- [x] Checked coverage/index.html - did not add any new code that's not covered by testing (if possible)
- [x] Ran the test suite - all tests are passing
- [x] Merged in the latest master to my branch with git pull origin master & resolved merge conflicts
- [x] I have commented my code, particularly in hard-to-understand areas

